### PR TITLE
Feature/smoothing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,6 @@ setup(
         'numpy==1.15.4',
         'torch==1.0.0',
         'torchvision==0.2.1',
+        'more-itertools==5.0.0',
     ]
 )

--- a/utils/smoothing.py
+++ b/utils/smoothing.py
@@ -1,0 +1,48 @@
+from abc import ABC
+
+import numpy as np
+import more_itertools as mit
+
+
+class Smoother(ABC):
+    def smooth(self, modes):
+        pass
+
+
+class MajorityVoteSmoother(Smoother):
+    def __init__(self, num_iterations, window_size, step_size=1):
+        self.num_iterations = num_iterations
+        self.half_window_size = int(window_size / 2)
+        self.step_size = step_size
+        self._dummy_mode = 'dummy'
+
+    def _pad(self, modes):
+        return np.concatenate((
+            self.half_window_size * [self._dummy_mode],
+            modes,
+            self.half_window_size * [self._dummy_mode]))
+
+    def smooth(self, modes):
+        tmp_modes = modes.copy()
+
+        for _ in range(self.num_iterations):
+            tmp_modes = self._smooth_step(tmp_modes)
+
+        return tmp_modes
+
+    def _smooth_step(self, modes):
+        padded_modes = self._pad(modes)
+        smoothed_modes = []
+        for window in mit.windowed(padded_modes, n=2*self.half_window_size + 1):
+
+            contained_modes, mode_counts = np.unique(
+                [w for w in window if w != self._dummy_mode],
+                return_counts=True)
+
+            most_prevalent_mode_index = np.argmax(mode_counts)
+            most_prevalent_mode = contained_modes[most_prevalent_mode_index]
+            smoothed_modes.append(most_prevalent_mode)
+            # print(f'Major mode:\t{most_prevalent_mode}\tin{window}')
+
+        assert len(modes) == len(smoothed_modes)
+        return np.array(smoothed_modes, dtype=np.str_)


### PR DESCRIPTION
Please check and merge the majority vote smoothing code.

It is used in the following way:

```Python
predictions = myCNN(validation_data)
majority_vote_smoother = MajorityVoteSmoother(num_iterations, window_size)
smoothed_modes = majority_vote_smoother.smooth(predictions)
```
In practice I mostly used the value `10` for `num_iterations`, and `30` for `window_size`. However, a 30 seconds smoothing window to me already seems quite huge. Nonetheless it gave the best accuracy values. To not completely 'shadow' the actual predictions of your CNN you could also play with smaller values for `window_size`. Using higher values for `num_iterations` almost came with no improvements.